### PR TITLE
Use dtype="object" in the full_profile creation

### DIFF
--- a/model_profiler/profiler.py
+++ b/model_profiler/profiler.py
@@ -69,7 +69,7 @@ def model_profiler(model, Batch_size, profile=Profile, use_units=units, verbose=
     
     full_profile = np.concatenate((
                                 np.asarray(Profile).reshape(-1,1),
-                                np.asarray(values).reshape(-1,1),
+                                np.asarray(values, dtype="object").reshape(-1,1),
                                 np.asarray(use_units).reshape(-1,1)
                                 )
                             , 1)


### PR DESCRIPTION
This PR request is to make the code work with the latest version of Numpy (1.24.3).

In the master branch, there is an error in the full_profile creation:
https://github.com/Mr-TalhaIlyas/Tensorflow-Keras-Model-Profiler/blob/d42bdb33feea1ce894573ca7e3a0507e7a6a1339/model_profiler/profiler.py#L70-L75

The error is:
```bash
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (5,) + inhomogeneous part.
```

The reason of the error is the list element "gpus". The values from which I want to create an array is 
```python
values
>>>  [['0', '1', '2', '3', '4', '5', '6', '7'], 0.0112, 0.5707, 11.1879, 42.6785]
```
However, this array creation fails, because the type of the elements are different (list and float). The type that can accommodate both is the Python object. When we specify the data type as Python object, we allow the array to have elements of different data types. Then it works without problem. 
